### PR TITLE
Avoid duplicated $app definitions

### DIFF
--- a/src/SpeedAnalyzer/Ajax/Diagnosis/Environment.php
+++ b/src/SpeedAnalyzer/Ajax/Diagnosis/Environment.php
@@ -5,15 +5,13 @@ namespace A3020\SpeedAnalyzer\Ajax\Diagnosis;
 use A3020\SpeedAnalyzer\Environment\LatestPhpVersion;
 use A3020\SpeedAnalyzer\Environment\MysqlVersion;
 use A3020\SpeedAnalyzer\PermissionsTrait;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Updater\Update;
 use Concrete\Core\View\View;
 
-class Environment extends \Concrete\Core\Controller\Controller implements ApplicationAwareInterface
+class Environment extends \Concrete\Core\Controller\Controller
 {
-    use ApplicationAwareTrait, PermissionsTrait;
+    use PermissionsTrait;
 
     public function view()
     {

--- a/src/SpeedAnalyzer/Ajax/Diagnosis/Location.php
+++ b/src/SpeedAnalyzer/Ajax/Diagnosis/Location.php
@@ -3,17 +3,15 @@
 namespace A3020\SpeedAnalyzer\Ajax\Diagnosis;
 
 use A3020\SpeedAnalyzer\PermissionsTrait;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Geolocator\GeolocationResult;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\Response;
 use Concrete\Core\View\View;
 use Exception;
 
-class Location extends \Concrete\Core\Controller\Controller implements ApplicationAwareInterface
+class Location extends \Concrete\Core\Controller\Controller
 {
-    use ApplicationAwareTrait, PermissionsTrait;
+    use PermissionsTrait;
 
     public function view()
     {

--- a/src/SpeedAnalyzer/Ajax/Diagnosis/Packages.php
+++ b/src/SpeedAnalyzer/Ajax/Diagnosis/Packages.php
@@ -3,15 +3,13 @@
 namespace A3020\SpeedAnalyzer\Ajax\Diagnosis;
 
 use A3020\SpeedAnalyzer\PermissionsTrait;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Support\Facade\Package;
 use Concrete\Core\View\View;
 
-class Packages extends \Concrete\Core\Controller\Controller implements ApplicationAwareInterface
+class Packages extends \Concrete\Core\Controller\Controller
 {
-    use ApplicationAwareTrait, PermissionsTrait;
+    use PermissionsTrait;
 
     public function view()
     {

--- a/src/SpeedAnalyzer/Ajax/QueryDetails.php
+++ b/src/SpeedAnalyzer/Ajax/QueryDetails.php
@@ -5,16 +5,14 @@ namespace A3020\SpeedAnalyzer\Ajax;
 use A3020\SpeedAnalyzer\Event\EventRepository;
 use A3020\SpeedAnalyzer\PermissionsTrait;
 use A3020\SpeedAnalyzer\Query\QueryRepository;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\Response;
 use Concrete\Core\Page\Page;
 use Concrete\Core\View\View;
 
-class QueryDetails extends \Concrete\Core\Controller\Controller implements ApplicationAwareInterface
+class QueryDetails extends \Concrete\Core\Controller\Controller
 {
-    use ApplicationAwareTrait, PermissionsTrait;
+    use PermissionsTrait;
 
     public function view($eventId = null)
     {

--- a/src/SpeedAnalyzer/Ajax/Reports.php
+++ b/src/SpeedAnalyzer/Ajax/Reports.php
@@ -5,13 +5,11 @@ namespace A3020\SpeedAnalyzer\Ajax;
 use A3020\SpeedAnalyzer\Entity\Report;
 use A3020\SpeedAnalyzer\PermissionsTrait;
 use A3020\SpeedAnalyzer\Report\ReportList;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Http\ResponseFactory;
 
-class Reports extends \Concrete\Core\Controller\Controller implements ApplicationAwareInterface
+class Reports extends \Concrete\Core\Controller\Controller
 {
-    use ApplicationAwareTrait, PermissionsTrait;
+    use PermissionsTrait;
 
     public function getPage()
     {

--- a/src/SpeedAnalyzer/Listener/OnShutdown.php
+++ b/src/SpeedAnalyzer/Listener/OnShutdown.php
@@ -4,15 +4,11 @@ namespace A3020\SpeedAnalyzer\Listener;
 
 use A3020\SpeedAnalyzer\Entity\ReportEvent;
 use A3020\SpeedAnalyzer\Report\WriteReport;
-use Concrete\Core\Application\ApplicationAwareInterface;
-use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Support\Facade\Log;
 use Exception;
 
-class OnShutdown extends BaseTrack implements ApplicationAwareInterface
+class OnShutdown extends BaseTrack
 {
-    use ApplicationAwareTrait;
-
     public function handle($event)
     {
         $reportEvent = new ReportEvent();


### PR DESCRIPTION
I have warnings about duplicated $app definitions.
Here's an example:

```
Concrete\Core\Controller\AbstractController
and
Concrete\Core\Application\ApplicationAwareTrait
define the same property ($app) in the composition of
A3020\SpeedAnalyzer\Ajax\Diagnosis\Environment.
```

that's because:
- classes that extends ApplicationAwareInterface+ApplicationAwareTrait classes are ApplicationAwareInterface and already have access to the stuff defined in ApplicationAwareTrait
- concrete5 controllers already have ApplicationAwareInterface+ApplicationAwareTrait (see https://github.com/concrete5/concrete5/blob/8.4.0/concrete/src/Controller/AbstractController.php#L14-L16)

PS: with https://github.com/concrete5/concrete5/pull/6835 you'd be able to see them without placing a breakpoint at `Whoops\Run::handleError()`